### PR TITLE
#15 [feat] 홈화면 카드 이미지 클릭시 검색 화면 이동

### DIFF
--- a/src/layout/Card/Card.tsx
+++ b/src/layout/Card/Card.tsx
@@ -1,10 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { webPath } from '../../router';
 import { scoreToImage } from '../../utils/ScoreToImage';
 
 const Card = ({ score, stockName }: { score: number; stockName: string }) => {
+  const navigate = useNavigate();
   const imgLink = scoreToImage(score);
 
+  const handleClick = (stockName: string) => {
+    navigate(webPath.search(), { state: { stockName } });
+  };
+
   return (
-    <div style={{ padding: '10px' }}>
+    <div onClick={() => handleClick(stockName)} style={{ padding: '10px' }}>
       <div> {stockName}</div>
       <img src={imgLink}></img>
     </div>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#15-home-componenent -> develop

### 변경 사항
홈화면 카드 이미지 클릭시 검색 화면 이동

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
