### PR TITLE
#15 [feat] 주식 탭 변경 시 지표 뷰 초기화

### DIFF
--- a/src/layout/CardList/CardList.tsx
+++ b/src/layout/CardList/CardList.tsx
@@ -5,12 +5,22 @@ import { ArrowButton, NoScrollbar } from './CardList.Style';
 import HotCard from '../HotCard/HotCard';
 import { useContext } from 'react';
 
-const CardList = ({ list, backgroundColor, isHot = false }: { list: CardInterface[]; backgroundColor?: string; isHot?: boolean }) => {
+const CardList = ({
+  list,
+  backgroundColor,
+  isHot = false,
+  apiRef,
+}: {
+  list: CardInterface[];
+  backgroundColor?: string;
+  isHot?: boolean;
+  apiRef: React.MutableRefObject<publicApiType>;
+}) => {
   const isMobile = window.innerWidth < 450;
 
   return (
     <NoScrollbar>
-      <ScrollMenu LeftArrow={!isMobile ? LeftArrow : undefined} RightArrow={!isMobile ? RightArrow : undefined}>
+      <ScrollMenu LeftArrow={!isMobile ? LeftArrow : undefined} RightArrow={!isMobile ? RightArrow : undefined} apiRef={apiRef}>
         {isHot
           ? list.map((item: CardInterface) => {
               return <HotCard key={item.stockId} score={item.score} stockName={item.symbolName} />;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -8,10 +8,11 @@ import risingTextDark from '../../assets/risingTextDark.svg';
 import descentTextLight from '../../assets/descentTextLight.svg';
 import descentTextDark from '../../assets/descentTextDark.svg';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSystemTheme } from '../../hooks/useSystemHook';
 import { fetchDescentStocks, fetchHotStocks, fetchRisingStocks } from '../../controllers/api';
 import { KOREA, OVERSEA } from '../../ts/Constants';
+import { VisibilityContext } from 'react-horizontal-scrolling-menu';
 
 const Home = () => {
   const [hotStocks, setHotStocks] = useState<CardInterface[][]>([[], []]);
@@ -21,6 +22,9 @@ const Home = () => {
 
   const isDarkMode = useSystemTheme();
   const tabMenu = ['국내주식', '해외주식'];
+  const hotStocksApiRef = useRef({} as React.ContextType<typeof VisibilityContext>);
+  const risingStocksApiRef = useRef({} as React.ContextType<typeof VisibilityContext>);
+  const descentStocksApiRef = useRef({} as React.ContextType<typeof VisibilityContext>);
 
   useEffect(() => {
     const fetchStocks = async () => {
@@ -41,7 +45,15 @@ const Home = () => {
     fetchStocks();
   }, []);
 
-  const handleTab = (index: number) => setTabIndex(index);
+  const handleTab = (index: number) => {
+    if (tabIndex === index) return;
+    const currentScrollPosition = window.scrollY;
+    setTabIndex(index);
+    hotStocksApiRef.current.scrollToItem(hotStocksApiRef.current.getItemByIndex('0'));
+    risingStocksApiRef.current.scrollToItem(risingStocksApiRef.current.getItemByIndex('0'));
+    descentStocksApiRef.current.scrollToItem(descentStocksApiRef.current.getItemByIndex('0'));
+    window.scrollTo(0, currentScrollPosition);
+  };
 
   const getImageSrc = (type: string) => {
     switch (type) {
@@ -67,11 +79,11 @@ const Home = () => {
           ))}
         </StyleTabMenu>
         <StyledImage src={getImageSrc('hot')} />
-        <CardList list={hotStocks[tabIndex]} isHot={true} />
+        <CardList list={hotStocks[tabIndex]} isHot={true} apiRef={hotStocksApiRef} />
         <StyledImage src={getImageSrc('rising')} />
-        <CardList list={risingStocks[tabIndex]} isHot={false} />
+        <CardList list={risingStocks[tabIndex]} isHot={false} apiRef={risingStocksApiRef} />
         <StyledImage src={getImageSrc('descent')} />
-        <CardList list={descentStocks[tabIndex]} isHot={false} />
+        <CardList list={descentStocks[tabIndex]} isHot={false} apiRef={descentStocksApiRef} />
       </StyledContainer>
     </StyledHome>
   );

--- a/src/ts/Enums.ts
+++ b/src/ts/Enums.ts
@@ -1,3 +1,0 @@
-const CURVIEWSTOCKCNT = 3;
-
-export { CURVIEWSTOCKCNT };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feat/#15 home component -> dev

### 변경 사항
탭 변경 시 첫번째 종목 정보 보여주도록 수정

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
