### PR TITLE
#66 [fix] wordcloud 브라우저별 폰트 위치 이상 비율 찾아서 맞춤

### DIFF
--- a/src/components/Search/SearchTitle/SearchTitle.Style.ts
+++ b/src/components/Search/SearchTitle/SearchTitle.Style.ts
@@ -113,7 +113,6 @@ export const SearchTitleBodyTitleText = styled.div({
 export const SearchTitleBodyTitleAnimatedText = styled(motion.div)({
   willChange: 'transform',
   position: 'absolute',
-  width: '100px',
   top: '0',
 
   color: theme.colors.primary0,

--- a/src/components/Search/SearchTitle/SearchTitle.tsx
+++ b/src/components/Search/SearchTitle/SearchTitle.tsx
@@ -52,6 +52,7 @@ const SearchTitle = ({
 
   const [summary] = StockSummaryQuery(stockInfo.symbol, stockInfo.country);
 
+  console.log((titleTextRef.current?.offsetWidth ?? 0) - (titleTextRef.current?.scrollWidth ?? 0));
   const variants: Variants = {
     initial: {
       transform: 'translateX(0%)',

--- a/src/components/Search/StockWordCloud/StockWordCloud.Style.ts
+++ b/src/components/Search/StockWordCloud/StockWordCloud.Style.ts
@@ -2,14 +2,7 @@ import styled from '@emotion/styled';
 import { pop } from '@styles/keyframes';
 import { media, theme, themeColor } from '@styles/themes';
 
-const WordColors: themeColor[] = [
-  'primary30',
-  'primary40',
-  'primary50',
-  'primary60',
-  'primary70',
-  'primary80',
-];
+const WordColors: themeColor[] = ['primary30', 'primary40', 'primary50', 'primary60', 'primary70', 'primary80'];
 
 const StockWordCloudContainer = styled.div({
   height: '720px',
@@ -21,6 +14,13 @@ const StockWordCloudContainer = styled.div({
     height: '480px',
     borderRadius: '12px',
   },
+});
+
+const WordCloudTestText = styled.span({
+  fontSize: '100px',
+  position: 'absolute',
+  lineHeight: '1',
+  color: theme.colors.transparent,
 });
 
 const WordContainer = styled.div(
@@ -74,4 +74,4 @@ const Word = styled.span(
   }),
 );
 
-export { StockWordCloudContainer, WordContainer, Word };
+export { StockWordCloudContainer, WordCloudTestText, WordContainer, Word };

--- a/src/components/Search/StockWordCloud/StockWordCloud.tsx
+++ b/src/components/Search/StockWordCloud/StockWordCloud.tsx
@@ -5,16 +5,16 @@ import { STOCK_COUNTRY } from '@ts/Types';
 import { useIsMobile } from '@hooks/useIsMobile';
 import LoadingComponent from '@components/Common/LoadingComponent';
 import { WordCloudQuery } from '@controllers/query';
-import { StockWordCloudContainer, Word, WordContainer } from './StockWordCloud.Style';
-
-const agent = window.navigator.userAgent.toLowerCase();
+import { StockWordCloudContainer, Word, WordCloudTestText, WordContainer } from './StockWordCloud.Style';
 
 const StockWordCloudContents = ({
   wordCloutItem: { orientation, pos, size, fontSize, color, word },
   index,
+  adjustFontSize,
 }: {
   wordCloutItem: WordCloudItem;
   index: number;
+  adjustFontSize: number;
 }) => {
   return (
     <WordContainer
@@ -23,7 +23,7 @@ const StockWordCloudContents = ({
       posY={pos.y}
       sizeX={size.w}
       sizeY={size.h}
-      fontSize={fontSize / (agent.indexOf('instagram') > -1 ? 1.1 : 1)}
+      fontSize={fontSize / adjustFontSize}
     >
       <Word orientation={orientation ? 1 : 0} colors={color}>
         {word}
@@ -49,6 +49,8 @@ const StockWordCloud = ({ symbol, country }: { symbol: string; country: STOCK_CO
     isMobile,
   );
 
+  const testTextRef = useRef<HTMLSpanElement>(null);
+
   useEffect(() => {
     if (symbol == state?.symbol) return;
     setCurrentIndex(-1);
@@ -68,13 +70,19 @@ const StockWordCloud = ({ symbol, country }: { symbol: string; country: STOCK_CO
 
   return (
     <StockWordCloudContainer ref={containerRef}>
+      <WordCloudTestText ref={testTextRef}>감자탕</WordCloudTestText>
       {wordCloud ? (
         [...wordCloud]
           .reverse()
           .map(
             (item: WordCloudItem, idx: number) =>
               wordCloud.length - idx <= currentIndex && (
-                <StockWordCloudContents key={idx} wordCloutItem={item} index={idx} />
+                <StockWordCloudContents
+                  key={idx}
+                  wordCloutItem={item}
+                  index={idx}
+                  adjustFontSize={(testTextRef.current?.offsetHeight ?? 0) / 100}
+                />
               ),
             6,
           )

--- a/src/controllers/query.ts
+++ b/src/controllers/query.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
-import { CHART_MOVING_AVERAGE_COLOR, CHART_PRICE_FIELD, TEXT_SIZE_ADJUST } from '@ts/Constants';
+import { CHART_MOVING_AVERAGE_COLOR, CHART_PRICE_FIELD } from '@ts/Constants';
 import { STOCK_COUNTRY } from '@ts/Types';
 import { formatDateISO, formatLocalDateToDate } from '@utils/Date';
 import { StockType } from '@components/Common/Common.Type';
@@ -116,8 +116,6 @@ const WordCloudWorker = new Worker(new URL('@utils/worker/GenerateWordCloud.ts',
   type: 'module',
 });
 
-const agent = window.navigator.userAgent.toLowerCase();
-
 export const WordCloudQuery = (symbol: string, country: STOCK_COUNTRY, { width, height }: any, isMobile: boolean) => {
   const [wordCloud, setWordCloud] = useState<any>([]);
 
@@ -136,19 +134,11 @@ export const WordCloudQuery = (symbol: string, country: STOCK_COUNTRY, { width, 
 
     if (!queryData) {
       fetchSearchWordCloud(symbol, country).then((res) => {
-        const adjust =
-          agent.indexOf('chrome') > -1 || agent.indexOf('firefox') > -1
-            ? TEXT_SIZE_ADJUST.chrome
-            : agent.indexOf('instagram') > -1
-              ? TEXT_SIZE_ADJUST.chrome
-              : TEXT_SIZE_ADJUST.safari;
-
         WordCloudWorker.postMessage({
           symbol,
           data: res,
           width,
           height,
-          adjust,
           isMobile,
         });
       });

--- a/src/ts/Constants.ts
+++ b/src/ts/Constants.ts
@@ -25,11 +25,6 @@ const MARKET_CODES: Record<string, string> = {
   '003': 'ETF',
 };
 
-const TEXT_SIZE_ADJUST = {
-  chrome: 0.055,
-  safari: -0.105,
-};
-
 const CHART_PRICE_FIELD = {
   open: { key: 'openPrice', label: '시가' },
   high: { key: 'highPrice', label: '고가' },
@@ -89,7 +84,6 @@ export {
   MARKET_CODES,
   STOCK_COUNTRY_TEXT,
   SEARCH_CATEGORY_TEXT,
-  TEXT_SIZE_ADJUST,
   CHART_PRICE_FIELD,
   CHART_SCALE_RATIO,
   PERIOD_CODE_TEXT,

--- a/src/utils/worker/GenerateWordCloud.ts
+++ b/src/utils/worker/GenerateWordCloud.ts
@@ -5,7 +5,6 @@ const GetnerateWordCloud = (params: {
   frequencies: WordFrequency[];
   height?: number;
   width: number;
-  adjust: number;
   wasm: any;
   minFontSize?: number;
   margin?: number;
@@ -17,7 +16,6 @@ const GetnerateWordCloud = (params: {
     frequencies,
     height = 300,
     width = 300,
-    adjust,
     wasm,
     minFontSize = 4,
     margin = 4,
@@ -26,9 +24,7 @@ const GetnerateWordCloud = (params: {
     maxFontSize,
   } = params;
 
-  frequencies = frequencies
-    .sort((a, b) => b.freq - a.freq || a.word.length - b.word.length)
-    .slice(0, maxWords);
+  frequencies = frequencies.sort((a, b) => b.freq - a.freq || a.word.length - b.word.length).slice(0, maxWords);
 
   const margin_gap = margin / 2;
   const layouts: WordCloudItem[] = [];
@@ -66,6 +62,10 @@ const GetnerateWordCloud = (params: {
 
   const FontOffCtx = new OffscreenCanvas(width, height).getContext('2d');
   if (!FontOffCtx) return null;
+  FontOffCtx.font = `10000px "PretendardBlack"`;
+  FontOffCtx.textBaseline = 'top';
+  const adjust = (10965.5 - FontOffCtx.measureText('감자탕').fontBoundingBoxDescent) / 10000;
+
   FontOffCtx.font = `${maxFontSize}px "PretendardBlack"`;
 
   frequencies.every(({ word, freq }) => {
@@ -88,8 +88,7 @@ const GetnerateWordCloud = (params: {
     offCtx.font = `${fontSize}px "PretendardBlack"`;
 
     const textX = margin_gap;
-    const textY =
-      (orientation ? -1 : 1) * margin_gap + fontSize * (!orientation ? adjust : -(1 - adjust));
+    const textY = (orientation ? -1 : 1) * margin_gap + fontSize * (!orientation ? adjust : -(1 - adjust));
     if (orientation) {
       offCtx.rotate((90 * Math.PI) / 180);
       offCtx.fillText(word, textX, textY);
@@ -119,15 +118,12 @@ const GetnerateWordCloud = (params: {
   return { width: width, height: height, layouts: layouts };
 };
 
-self.onmessage = ({ data: { symbol, data, width, height, adjust, isMobile } }) => {
+self.onmessage = ({ data: { symbol, data, width, height, isMobile } }) => {
   if (!self.FontFace) {
     postMessage("Your browser doesn't support the FontFace API from WebWorkers yet");
     return;
   }
-  const fontFace = new FontFace(
-    'PretendardBlack',
-    "url(/fonts/Pretendard-Black.woff2) format('woff2')",
-  );
+  const fontFace = new FontFace('PretendardBlack', "url(/fonts/Pretendard-Black.woff2) format('woff2')");
   self.fonts.add(fontFace);
 
   fontFace.load().then(async () => {
@@ -144,7 +140,6 @@ self.onmessage = ({ data: { symbol, data, width, height, adjust, isMobile } }) =
         frequencies: data,
         height: height,
         width: width,
-        adjust: adjust,
         minFontSize: !isMobile ? 7 : 5,
         margin: !isMobile ? 4 : 3,
         maxWords: !isMobile ? 800 : 600,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
 feat/#66-stock-word-cloud -> develop

### 변경 사항
 기존 사파리랑 크롬 판별해서 적당한 값 넣었던 거 그냥 measuretext 폰트 사이즈 늘려가면서 대략적인 비율값 찾음
 폰트사이즈 10000일때 기준으로 판별함
 => (10965.5 - fontBoundingBoxDescent) / 10000
